### PR TITLE
Update ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,3 +7,4 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=1800s
 forks = 19
 host_key_checking = False
 callback_whitelist = profile_tasks
+transport = paramiko


### PR DESCRIPTION
Had to update a param in ansible.cfg for fixing error below.
```
transport = paramiko
```
```
TASK [register-virtual-machines : Force unregister before register] *************************************************************************
Thursday 23 November 2017  15:24:05 -0500 (0:00:01.040)       0:09:04.716 *****
fatal: [34.239.167.103]: FAILED! => {"changed": false, "failed": true, "module_stderr": "sudo: sorry, you must have a tty to run sudo\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```