### PR TITLE
Add fix for https://github.com/gnunn1/openshift-aws-setup/issues/4

### DIFF
--- a/roles/teardown-virtual-machines/tasks/main.yml
+++ b/roles/teardown-virtual-machines/tasks/main.yml
@@ -25,8 +25,9 @@
     ip: "{{item.public_ip_address}}"
     region: "{{region}}"
     state: absent
+    release_on_disassociation: yes
   with_items: "{{ ec2_facts.instances }}"
-  when: ((item is defined) and (item.tags.Name == 'master-' ~ namespace) and (item.state != 'terminated'))
+  when: ((item is defined) and ('master' in item.tags.Name) and (item.state != 'terminated'))
 
 - name: Terminate EC2 VMs
   ec2:

--- a/roles/teardown-virtual-machines/tasks/main.yml
+++ b/roles/teardown-virtual-machines/tasks/main.yml
@@ -27,7 +27,7 @@
     state: absent
     release_on_disassociation: yes
   with_items: "{{ ec2_facts.instances }}"
-  when: ((item is defined) and ('master' in item.tags.Name) and (item.state != 'terminated'))
+  when: ((item is defined) and (item.tags.Name == 'master-' ~ namespace) and (item.state != 'terminated'))
 
 - name: Terminate EC2 VMs
   ec2:


### PR DESCRIPTION
Automatically release the EIP when it is disassociated with `release_on_disassociation` (added in 2.0), and updated conditional statement to check for 'master' string in ec2 Name tag since Jinja2 can do sub-string checks with the 'in' comparison and the registered `ec2_facts` variable already filters by the namespace tag.